### PR TITLE
feat: git clone support for 3rd party repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-fivem-app",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -613,6 +613,14 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1301,6 +1309,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/itschip/create-fivem-app#readme",
   "dependencies": {
     "@types/rimraf": "^3.0.0",
+    "axios": "^0.21.1",
     "chalk": "^4.1.0",
     "clear": "^0.1.0",
     "figlet": "^1.5.0",

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -3,9 +3,18 @@ import promptResource from '../prompts/promptResource';
 import promptPackages from '../prompts/promptPackages'
 import { supportedLanguage, hasPackages } from '../types/index';
 import createResource from '../functions/createResource';
+import { cloneResource } from '../functions/cloneResource';
 // Create command functionality
 export const createCommand = async () => {
+  const getUrlParam = process.argv.find(arg => arg.startsWith('http'))
+
   const resourceName = await promptResource()
+
+  if (getUrlParam != null) {
+    await cloneResource(resourceName.val, getUrlParam)
+    return
+  }
+
   const language = await promptLanguage()
   let packages = null
   if (hasPackages.includes(language.val)) {

--- a/src/functions/cloneResource.ts
+++ b/src/functions/cloneResource.ts
@@ -1,0 +1,39 @@
+import axios from "axios"
+import shell from 'shelljs';
+import ora from 'ora';
+
+export const cloneResource = async (resourceName: string, url: string): Promise<void> => {
+  try {
+    const query = await axios.get(url)
+    if (query.status !== 200) {
+      console.log('URL not found')
+      return
+    }
+  } catch (e) {
+    console.error('Could not validate URL')
+    return
+  }
+
+  try {
+    if (
+      shell.exec(
+        `git clone ${url} ${resourceName}`
+      ).code !== 0
+    ) {
+      shell.exit(1);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+
+  const spinner = ora("Installing packages...").start();
+
+  spinner.succeed("Successfully added default packages");
+  try {
+    if (shell.exec(`cd ${resourceName} && yarn --silent && rm -rf .git && rm -rf .github`).code !== 0) {
+      shell.exit(1);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}


### PR DESCRIPTION
- I intentionally didn't add sugary parsing a la `githubuser/reponame` so this still works for any git repos online
- Pulled in axios as a safeguard which GET request's the given URL to make sure it is available and a valid URL
- Automatically deletes .git and .github (potentially may need adding more later, or .github removal reverse?) so it doesn't weirdly add it as a submodule (besides, it's a template, if you make changes to the template you wouldn't clone it this way)
- Still allows for resource name input